### PR TITLE
Remove update attribute on md5sum read

### DIFF
--- a/drivesink.py
+++ b/drivesink.py
@@ -74,7 +74,7 @@ class CloudNode(object):
 
     def _md5sum(self, filename, blocksize=65536):
         md5 = hashlib.md5()
-        with open(filename, "r+b") as f:
+        with open(filename, "rb") as f:
             for block in iter(lambda: f.read(blocksize), ""):
                 md5.update(block)
         return md5.hexdigest()


### PR DESCRIPTION
The md5sum block shouldn't need file update permissions, and it causes a permission denied error when the files to upload are read-only.