### PR TITLE
download raw file, not html to github page

### DIFF
--- a/drivesink/templates/index.html
+++ b/drivesink/templates/index.html
@@ -37,7 +37,7 @@
     <p>
       <ul>
         <li>
-          First download <a href="https://github.com/caseymrm/drivesink/blob/master/drivesink.py">the script</a>:
+          First download <a href="https://raw.githubusercontent.com/caseymrm/drivesink/master/drivesink.py">the script</a>:
           <pre>curl -O https://github.com/caseymrm/drivesink/blob/master/drivesink.py</pre>
         </li>
         <li>Then get your <a href="/config">access configuration</a> by logging in with Amazon</li>

--- a/drivesink/templates/index.html
+++ b/drivesink/templates/index.html
@@ -37,8 +37,8 @@
     <p>
       <ul>
         <li>
-          First download <a href="https://raw.githubusercontent.com/caseymrm/drivesink/master/drivesink.py">the script</a>:
-          <pre>curl -O https://github.com/caseymrm/drivesink/blob/master/drivesink.py</pre>
+          First download <a href="https://github.com/caseymrm/drivesink/blob/master/drivesink.py">the script</a>:
+          <pre>curl -O https://raw.githubusercontent.com/caseymrm/drivesink/master/drivesink.py</pre>
         </li>
         <li>Then get your <a href="/config">access configuration</a> by logging in with Amazon</li>
         <li>


### PR DESCRIPTION
# problem
The current link refers to the html github page for the file, but not the python file itself

# solution
Change URL to github's RAW link means we'll actually pull down the raw python file now 🎅